### PR TITLE
Adding One UI to the list of supported launchers

### DIFF
--- a/app/src/main/res/values/launchers.xml
+++ b/app/src/main/res/values/launchers.xml
@@ -22,6 +22,7 @@
         <item>nougat</item>
         <item>nova</item>
         <item>omega</item>
+        <item>one_ui</item>
         <item>pixel</item>
         <item>poco</item>
         <item>posidon</item>


### PR DESCRIPTION
One UI supported in the main repo: https://github.com/zixpo/candybar/pull/122/commits/ce4d59ae52c864fdf6fda6d94c36b354fc7269e0#diff-de3100688ec2a1fd6b801c3cf0b91732633cc31d52c79c65b0de97371b57877a

It hasn't been added to the sample project.