### PR TITLE
Expose status bar color in candybar-sample

### DIFF
--- a/app/src/main/res/values-night/themes.xml
+++ b/app/src/main/res/values-night/themes.xml
@@ -4,6 +4,8 @@
         <item name="cb_colorPrimary">#222222</item>
         <item name="cb_colorPrimaryDark">#222222</item>
         <item name="cb_colorAccent">#1BB96F</item>
+        <!-- Fallback status bar color for Android 9 and below -->
+        <item name="android:statusBarColor">?attr/cb_colorPrimary</item>
 
         <!-- Navigation Bar -->
         <item name="cb_navigationBar">#222222</item>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -4,6 +4,8 @@
         <item name="cb_colorPrimary">#35C164</item>
         <item name="cb_colorPrimaryDark">#4CAF50</item>
         <item name="cb_colorAccent">#1BB96F</item>
+        <!-- Fallback status bar color for Android 9 and below -->
+        <item name="android:statusBarColor">?attr/cb_colorPrimary</item>
 
         <!-- Navigation Bar -->
         <item name="cb_navigationBar">#1A73E9</item>


### PR DESCRIPTION
This PR updates the CandyBar sample project themes.xml to show a recommended way for icon pack developers to control/change the status bar color on Android 9 and below.

Matches the fix in the main CandyBar library for the white status bar issue on Android 9 and below (zixpo/candybar#183).

Gives icon pack developers a clear example of how to override the status bar color in their own icon packs while still using the CandyBar dashboard theme.

Related to zixpo/candybar#183